### PR TITLE
feat(*)!: Updates to latest oci-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,10 +669,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oci-distribution"
-version = "0.11.0"
+name = "oci-client"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a2c51531af0cb93761f66094044ca6ea879320bccd35ab747ff3fcab3f422"
+checksum = "ce611137700c3ec179993d5357dddde194bd706690b361f2f6b9235d4e29830e"
 dependencies = [
  "bytes",
  "chrono",
@@ -695,11 +695,11 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "chrono",
- "oci-distribution",
+ "oci-client",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "oci-wasm"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 authors = ["Taylor Thomas <taylor@oftaylor.com>"]
-description = "A crate containing a thin wrapper around the oci-distribution crate that implements types and methods for pulling and pushing Wasm to OCI registries"
+description = "A crate containing a thin wrapper around the oci-client crate that implements types and methods for pulling and pushing Wasm to OCI registries"
 repository = "https://github.com/bytecodealliance/rust-oci-wasm"
 license-file = "LICENSE"
 keywords = ["wasm", "oci", "webassembly"]
@@ -12,13 +12,13 @@ keywords = ["wasm", "oci", "webassembly"]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["oci-distribution/native-tls"]
-rustls-tls = ["oci-distribution/rustls-tls"]
+default = ["oci-client/native-tls"]
+rustls-tls = ["oci-client/rustls-tls"]
 
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-oci-distribution = { version = "0.11", default-features = false }
+oci-client = { version = "0.12", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, ops::Deref};
+use std::{collections::BTreeMap, ops::Deref};
 
-use oci_distribution::{
+use oci_client::{
     client::{ImageData, ImageLayer, PushResponse},
     manifest::OciImageManifest,
     secrets::RegistryAuth,
@@ -107,7 +107,7 @@ impl WasmClient {
         auth: &RegistryAuth,
         component_layer: ImageLayer,
         config: impl ToConfig,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> anyhow::Result<PushResponse> {
         let layers = vec![component_layer];
         let config = config.to_config()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
-use oci_distribution::client::{Config, ImageLayer};
+use oci_client::client::{Config, ImageLayer};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
@@ -44,7 +44,7 @@ pub struct WasmConfig {
 
 pub struct AnnotatedWasmConfig<'a> {
     pub config: &'a WasmConfig,
-    pub annotations: HashMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
 }
 
 impl WasmConfig {
@@ -121,7 +121,7 @@ impl WasmConfig {
     #[must_use]
     pub fn with_annotations(
         &'_ self,
-        annotations: HashMap<String, String>,
+        annotations: BTreeMap<String, String>,
     ) -> AnnotatedWasmConfig<'_> {
         AnnotatedWasmConfig {
             config: self,


### PR DESCRIPTION
This was a breaking change because we need to change to use a BTreeMap to match the changes to the oci-client API