### PR TITLE
Specify license alongside license-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "oci-wasm"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 authors = ["Taylor Thomas <taylor@oftaylor.com>"]
 description = "A crate containing a thin wrapper around the oci-client crate that implements types and methods for pulling and pushing Wasm to OCI registries"
 repository = "https://github.com/bytecodealliance/rust-oci-wasm"
+license = "Apache-2.0"
 license-file = "LICENSE"
 keywords = ["wasm", "oci", "webassembly"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Taylor Thomas <taylor@oftaylor.com>"]
 description = "A crate containing a thin wrapper around the oci-client crate that implements types and methods for pulling and pushing Wasm to OCI registries"
 repository = "https://github.com/bytecodealliance/rust-oci-wasm"
-license = "Apache-2.0"
+license = "Apache-2.0 WITH LLVM-exception"
 license-file = "LICENSE"
 keywords = ["wasm", "oci", "webassembly"]
 


### PR DESCRIPTION
Fixes #13 

Many automated tools read known-licenses based on the `license` tool and the SPDX spec. Though the `license-file` key is standard, it's usually used for custom licenses and are usually banned-by-default by scanners.

This PR adds the `license` alongside `license-file`, since the Apache 2.0 is a standard license. Also bumps to 0.0.6.