### PR TITLE
chore(deps): Bump oci-client to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e050f8bab3f561aa5ab537e1a6ed24006d58b4ee93cd6bb2c0cb822726f306"
+checksum = "474675fdc023fbcc9dcf4782e938a3a1ae5fd469c728d8db40599bd25c77e1ba"
 dependencies = [
  "bytes",
  "chrono",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oci-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Taylor Thomas <taylor@oftaylor.com>"]
 description = "A crate containing a thin wrapper around the oci-client crate that implements types and methods for pulling and pushing Wasm to OCI registries"
@@ -19,7 +19,7 @@ rustls-tls = ["oci-client/rustls-tls"]
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-oci-client = { version = "0.13", default-features = false }
+oci-client = { version = "0.14", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"


### PR DESCRIPTION
Since https://github.com/oras-project/rust-oci-client/pull/180 landed and  [got released](https://github.com/oras-project/rust-oci-client/releases/tag/v0.14.0), seemed like a good reason to upgrade.