### PR TITLE
Upgrade wasm-tools packages to 0.224

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tokio = { version = "1", default-features = false, features = ["fs"] }
-wit-component = "0.219"
-wit-parser = "0.219"
+wit-component = "0.224"
+wit-parser = "0.224"
 
 [dev-dependencies]
 testcontainers = { version = "0.23", features = ["watchdog"] }


### PR DESCRIPTION
Specifically to pull in https://github.com/bytecodealliance/wasm-tools/pull/1958 which fixes parsing of (unpublished) `wasi:http@0.2.3`.